### PR TITLE
test(acs-decorators): add tests for acs-decorators, and simplify usage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6915,18 +6915,6 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
@@ -11158,9 +11146,10 @@
       }
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
-      "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "license": "Apache-2.0",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -23277,9 +23266,10 @@
       "dev": true
     },
     "node_modules/typescript": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
-      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -25455,10 +25445,292 @@
         "npm-run-all": "^4.1.5",
         "rimraf": "^6.0.1",
         "should": "^13.2.3",
-        "ts-node": "^10.9.1",
-        "typescript": "^5.6.2",
-        "typescript-eslint": "8.11.0",
+        "ts-node": "^10.9.2",
+        "typescript": "^5.9.2",
+        "typescript-eslint": "8.44.1",
         "vitest": "^2.1.4"
+      }
+    },
+    "packages/acs-client/node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.44.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.44.1.tgz",
+      "integrity": "sha512-molgphGqOBT7t4YKCSkbasmu1tb1MgrZ2szGzHbclF7PNmOkSTQVHy+2jXOSnxvR3+Xe1yySHFZoqMpz3TfQsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.10.0",
+        "@typescript-eslint/scope-manager": "8.44.1",
+        "@typescript-eslint/type-utils": "8.44.1",
+        "@typescript-eslint/utils": "8.44.1",
+        "@typescript-eslint/visitor-keys": "8.44.1",
+        "graphemer": "^1.4.0",
+        "ignore": "^7.0.0",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.1.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.44.1",
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "packages/acs-client/node_modules/@typescript-eslint/parser": {
+      "version": "8.44.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.44.1.tgz",
+      "integrity": "sha512-EHrrEsyhOhxYt8MTg4zTF+DJMuNBzWwgvvOYNj/zm1vnaD/IC5zCXFehZv94Piqa2cRFfXrTFxIvO95L7Qc/cw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.44.1",
+        "@typescript-eslint/types": "8.44.1",
+        "@typescript-eslint/typescript-estree": "8.44.1",
+        "@typescript-eslint/visitor-keys": "8.44.1",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "packages/acs-client/node_modules/@typescript-eslint/project-service": {
+      "version": "8.44.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.44.1.tgz",
+      "integrity": "sha512-ycSa60eGg8GWAkVsKV4E6Nz33h+HjTXbsDT4FILyL8Obk5/mx4tbvCNsLf9zret3ipSumAOG89UcCs/KRaKYrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.44.1",
+        "@typescript-eslint/types": "^8.44.1",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "packages/acs-client/node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.44.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.44.1.tgz",
+      "integrity": "sha512-NdhWHgmynpSvyhchGLXh+w12OMT308Gm25JoRIyTZqEbApiBiQHD/8xgb6LqCWCFcxFtWwaVdFsLPQI3jvhywg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.44.1",
+        "@typescript-eslint/visitor-keys": "8.44.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "packages/acs-client/node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.44.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.44.1.tgz",
+      "integrity": "sha512-B5OyACouEjuIvof3o86lRMvyDsFwZm+4fBOqFHccIctYgBjqR3qT39FBYGN87khcgf0ExpdCBeGKpKRhSFTjKQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "packages/acs-client/node_modules/@typescript-eslint/type-utils": {
+      "version": "8.44.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.44.1.tgz",
+      "integrity": "sha512-KdEerZqHWXsRNKjF9NYswNISnFzXfXNDfPxoTh7tqohU/PRIbwTmsjGK6V9/RTYWau7NZvfo52lgVk+sJh0K3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.44.1",
+        "@typescript-eslint/typescript-estree": "8.44.1",
+        "@typescript-eslint/utils": "8.44.1",
+        "debug": "^4.3.4",
+        "ts-api-utils": "^2.1.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "packages/acs-client/node_modules/@typescript-eslint/types": {
+      "version": "8.44.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.44.1.tgz",
+      "integrity": "sha512-Lk7uj7y9uQUOEguiDIDLYLJOrYHQa7oBiURYVFqIpGxclAFQ78f6VUOM8lI2XEuNOKNB7XuvM2+2cMXAoq4ALQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "packages/acs-client/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.44.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.44.1.tgz",
+      "integrity": "sha512-qnQJ+mVa7szevdEyvfItbO5Vo+GfZ4/GZWWDRRLjrxYPkhM+6zYB2vRYwCsoJLzqFCdZT4mEqyJoyzkunsZ96A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.44.1",
+        "@typescript-eslint/tsconfig-utils": "8.44.1",
+        "@typescript-eslint/types": "8.44.1",
+        "@typescript-eslint/visitor-keys": "8.44.1",
+        "debug": "^4.3.4",
+        "fast-glob": "^3.3.2",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^2.1.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "packages/acs-client/node_modules/@typescript-eslint/utils": {
+      "version": "8.44.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.44.1.tgz",
+      "integrity": "sha512-DpX5Fp6edTlocMCwA+mHY8Mra+pPjRZ0TfHkXI8QFelIKcbADQz1LUPNtzOFUriBB2UYqw4Pi9+xV4w9ZczHFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.7.0",
+        "@typescript-eslint/scope-manager": "8.44.1",
+        "@typescript-eslint/types": "8.44.1",
+        "@typescript-eslint/typescript-estree": "8.44.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "packages/acs-client/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.44.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.44.1.tgz",
+      "integrity": "sha512-576+u0QD+Jp3tZzvfRfxon0EA2lzcDt3lhUbsC6Lgzy9x2VR4E+JUiNyGHi5T8vk0TV+fpJ5GLG1JsJuWCaKhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.44.1",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "packages/acs-client/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "packages/acs-client/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "packages/acs-client/node_modules/ts-api-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
+      "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
+    "packages/acs-client/node_modules/typescript-eslint": {
+      "version": "8.44.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.44.1.tgz",
+      "integrity": "sha512-0ws8uWGrUVTjEeN2OM4K1pLKHK/4NiNP/vz6ns+LjT/6sqpaYzIVFajZb1fj/IDwpsrrHb3Jy0Qm5u9CPcKaeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.44.1",
+        "@typescript-eslint/parser": "8.44.1",
+        "@typescript-eslint/typescript-estree": "8.44.1",
+        "@typescript-eslint/utils": "8.44.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "packages/chassis-srv": {
@@ -25924,19 +26196,6 @@
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
       },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "packages/chassis-srv/node_modules/eslint-visitor-keys": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
-      "dev": true,
-      "license": "Apache-2.0",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -10041,15 +10041,6 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="
     },
-    "node_modules/deepdash": {
-      "version": "5.3.9",
-      "resolved": "https://registry.npmjs.org/deepdash/-/deepdash-5.3.9.tgz",
-      "integrity": "sha512-GRzJ0q9PDj2T+J2fX+b+TlUa2NlZ11l6vJ8LHNKVGeZ8CfxCuJaCychTq07iDRTvlfO8435jlvVS1QXBrW9kMg==",
-      "dependencies": {
-        "lodash": "^4.17.21",
-        "lodash-es": "^4.17.21"
-      }
-    },
     "node_modules/deepmerge": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
@@ -16133,11 +16124,6 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-    },
-    "node_modules/lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
     },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
@@ -25422,7 +25408,6 @@
         "@restorecommerce/logger": "^1.3.6",
         "@restorecommerce/rc-grpc-clients": "^5.1.60",
         "@restorecommerce/service-config": "^1.1.5",
-        "deepdash": "^5.3.9",
         "lodash": "^4.17.21",
         "nconf": "^0.12.1",
         "node-eval": "^2.0.0",
@@ -28570,7 +28555,7 @@
         "npm-run-all": "^4.1.5",
         "rimraf": "^6.0.1",
         "should": "^13.2.3",
-        "typescript": "^5.6.3",
+        "typescript": "^5.9.2",
         "vitest": "^3.2.4"
       },
       "engines": {

--- a/packages/acs-client/cfg/config.json
+++ b/packages/acs-client/cfg/config.json
@@ -97,6 +97,7 @@
       "address": "localhost:50061"
     },
     "user": {
+      "fullName": "io.restorecommerce.user.UserService",
       "address": "localhost:50051"
     },
     "graph-srv": {
@@ -109,8 +110,6 @@
     "enforce": true,
     "urns": {
       "entity": "urn:restorecommerce:acs:names:model:entity",
-      "user": "urn:test:acs:model:user.User",
-      "model": "urn:test:acs:model",
       "role": "urn:restorecommerce:acs:names:role",
       "roleScopingEntity": "urn:restorecommerce:acs:names:roleScopingEntity",
       "roleScopingInstance": "urn:restorecommerce:acs:names:roleScopingInstance",
@@ -119,7 +118,6 @@
       "property": "urn:restorecommerce:acs:names:model:property",
       "ownerIndicatoryEntity": "urn:restorecommerce:acs:names:ownerIndicatoryEntity",
       "ownerInstance": "urn:restorecommerce:acs:names:ownerInstance",
-      "orgScope": "urn:test:acs:model:organization.Organization",
       "subjectID": "urn:oasis:names:tc:xacml:1.0:subject:subject-id",
       "resourceID": "urn:oasis:names:tc:xacml:1.0:resource:resource-id",
       "actionID": "urn:oasis:names:tc:xacml:1.0:action:action-id",
@@ -132,22 +130,11 @@
       "read": "urn:restorecommerce:acs:names:action:read",
       "modify": "urn:restorecommerce:acs:names:action:modify",
       "delete": "urn:restorecommerce:acs:names:action:delete",
-      "organization": "urn:test:acs:model:organization.Organization",
       "aclIndicatoryEntity": "urn:restorecommerce:acs:names:aclIndicatoryEntity",
       "aclInstance": "urn:restorecommerce:acs:names:aclInstance",
       "skipACL": "urn:restorecommerce:acs:names:skipACL",
       "maskedProperty": "urn:restorecommerce:acs:names:obligation:maskedProperty"
     },
-    "filterParamKey": [
-      {
-        "scopingEntity": "urn:test:acs:model:organization.Organization",
-        "value": "orgKey"
-      },
-      {
-        "scopingEntity": "urn:test:acs:model:user.User",
-        "value": "userKey"
-      }
-    ],
     "hierarchicalResources": [
       {
         "collection": "organizations",
@@ -168,16 +155,20 @@
   },
   "errors": {
     "INVALID_CREDENTIALS": {
-      "code": "001",
+      "code": 401,
       "message": "Invalid credentials"
     },
     "USER_NOT_LOGGED_IN": {
-      "code": "002",
+      "code": 401,
       "message": "User not logged in, please login first!"
     },
     "ACTION_NOT_ALLOWED": {
-      "code": "403",
+      "code": 403,
       "message": "Action not allowed on this resource"
+    },
+    "SYSTEM_ERROR": {
+      "code": 500,
+      "message": "System Error!"
     }
   }
 }

--- a/packages/acs-client/cfg/config.json
+++ b/packages/acs-client/cfg/config.json
@@ -97,7 +97,6 @@
       "address": "localhost:50061"
     },
     "user": {
-      "fullName": "io.restorecommerce.user.UserService",
       "address": "localhost:50051"
     },
     "graph-srv": {
@@ -109,6 +108,9 @@
     "enabled": true,
     "enforce": true,
     "urns": {
+      "model": "urn:restorecommerce:acs:model",
+      "user": "urn:restorecommerce:acs:model:user.User",
+      "organization": "urn:restorecommerce:acs:model:organization.Organization",
       "entity": "urn:restorecommerce:acs:names:model:entity",
       "role": "urn:restorecommerce:acs:names:role",
       "roleScopingEntity": "urn:restorecommerce:acs:names:roleScopingEntity",

--- a/packages/acs-client/cfg/config_test.json
+++ b/packages/acs-client/cfg/config_test.json
@@ -2,9 +2,56 @@
   "logger": {
     "console": {
       "handleExceptions": false,
-      "level": "silly",
+      "level": "error",
       "colorize": true,
       "prettyPrint": true
+    }
+  },
+  "authorization": {
+    "urns": {
+      "user": "urn:test:acs:model:user.User",
+      "model": "urn:test:acs:model",
+      "orgScope": "urn:test:acs:model:organization.Organization",
+      "organization": "urn:test:acs:model:organization.Organization",
+      "contact_point": "urn:test:acs:model:contact_point.ContactPoint"
+    },
+    "filterParamKey": [
+      {
+        "scopingEntity": "urn:test:acs:model:organization.Organization",
+        "value": "orgKey"
+      },
+      {
+        "scopingEntity": "urn:test:acs:model:user.User",
+        "value": "userKey"
+      }
+    ]
+  },
+  "client": {
+    "acs-srv": {
+      "address": "localhost:50161",
+      "mock": {
+        "protoPath": "io/restorecommerce/access_control.proto",
+        "packageName": "io.restorecommerce.access_control",
+        "serviceName": "AccessControlService",
+        "protoLoadOptions": {
+          "includeDirs": [
+            "../protos/"
+          ]
+        }
+      }
+    },
+    "user": {
+      "address": "localhost:50162",
+      "mock": {
+        "protoPath": "io/restorecommerce/user.proto",
+        "packageName": "io.restorecommerce.user",
+        "serviceName": "UserService",
+        "protoLoadOptions": {
+          "includeDirs": [
+            "../protos/"
+          ]
+        }
+      }
     }
   }
 }

--- a/packages/acs-client/cfg/config_test.json
+++ b/packages/acs-client/cfg/config_test.json
@@ -2,17 +2,17 @@
   "logger": {
     "console": {
       "handleExceptions": false,
-      "level": "error",
+      "level": "silly",
       "colorize": true,
       "prettyPrint": true
     }
   },
   "authorization": {
     "urns": {
-      "user": "urn:test:acs:model:user.User",
       "model": "urn:test:acs:model",
-      "orgScope": "urn:test:acs:model:organization.Organization",
+      "user": "urn:test:acs:model:user.User",
       "organization": "urn:test:acs:model:organization.Organization",
+      "orgScope": "urn:test:acs:model:organization.Organization",
       "contact_point": "urn:test:acs:model:contact_point.ContactPoint"
     },
     "filterParamKey": [
@@ -29,6 +29,7 @@
   "client": {
     "acs-srv": {
       "address": "localhost:50161",
+      "fullName": "io.restorecommerce.access_control.AccessControlService",
       "mock": {
         "protoPath": "io/restorecommerce/access_control.proto",
         "packageName": "io.restorecommerce.access_control",
@@ -42,6 +43,7 @@
     },
     "user": {
       "address": "localhost:50162",
+      "fullName": "io.restorecommerce.user.UserService",
       "mock": {
         "protoPath": "io/restorecommerce/user.proto",
         "packageName": "io.restorecommerce.user",

--- a/packages/acs-client/package.json
+++ b/packages/acs-client/package.json
@@ -46,9 +46,9 @@
     "npm-run-all": "^4.1.5",
     "rimraf": "^6.0.1",
     "should": "^13.2.3",
-    "ts-node": "^10.9.1",
-    "typescript": "^5.6.2",
-    "typescript-eslint": "8.11.0",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.9.2",
+    "typescript-eslint": "8.44.1",
     "vitest": "^2.1.4"
   },
   "scripts": {
@@ -57,7 +57,9 @@
     "build:clean": "rimraf lib",
     "build": "npm-run-all lint build:clean build:tsc",
     "lint": "eslint src",
-    "test": "npm run build && cross-env NODE_ENV=test vitest run && cross-env NODE_ENV=test CACHE_ENABLED=true vitest run"
+    "test:cache:disabled": "cross-env NODE_ENV=test vitest run",
+    "test:cache:enabled": "cross-env NODE_ENV=test CACHE_ENABLED=true vitest run",
+    "test": "npm-run-all build test:cache:disabled test:cache:enabled"
   },
   "nx": {
     "targets": {

--- a/packages/acs-client/package.json
+++ b/packages/acs-client/package.json
@@ -23,7 +23,6 @@
     "@restorecommerce/logger": "^1.3.6",
     "@restorecommerce/rc-grpc-clients": "^5.1.60",
     "@restorecommerce/service-config": "^1.1.5",
-    "deepdash": "^5.3.9",
     "lodash": "^4.17.21",
     "nconf": "^0.12.1",
     "node-eval": "^2.0.0",

--- a/packages/acs-client/src/acs/authz.ts
+++ b/packages/acs-client/src/acs/authz.ts
@@ -13,7 +13,7 @@ import {
   ACSResource,
 } from './interfaces.js';
 import { createChannel, createClient } from '@restorecommerce/grpc-client';
-import { cfg, updateConfig } from '../config.js';
+import { cfg, updateConfig, urns } from '../config.js';
 import logger, { setLogger, getLogger } from '../logger.js';
 import { flushCache, getOrFill } from './cache.js';
 import { Events, registerProtoMeta } from '@restorecommerce/kafka-client';
@@ -42,7 +42,6 @@ registerProtoMeta(
 export declare type Authorizer = ACSAuthZ;
 export let authZ: Authorizer;
 export let unauthZ: UnAuthZ;
-const urns = cfg.get('authorization:urns');
 
 export const createActionTarget = (action: any): Attribute[] => {
   if (Array.isArray(action)) {
@@ -127,7 +126,7 @@ export const createResourceTarget = (resource: ACSResource[], action: AuthZActio
       }
 
       // entity - urn:restorecommerce:acs:names:model:entity
-      const entityName = urns[resourceName]
+      const entityName = (urns as any)[resourceName]
         ?? `${urns.model}:${formatResourceType(resourceName, resourceNameSpace)}`;
       flattened.push({
         id: urns.entity,

--- a/packages/acs-client/src/acs/cache.ts
+++ b/packages/acs-client/src/acs/cache.ts
@@ -52,8 +52,12 @@ export const initializeCache = async () => {
  * @param filler The function to execute if key is not found in cache
  * @param prefix The prefix to apply to the object key in the cache
  */
-export const getOrFill = async <T, M>(keyData: T, filler: (data: T) => Promise<M>,
-  useCache: boolean, prefix?: string): Promise<M> => {
+export const getOrFill = async <T, M>(
+  keyData: T,
+  filler: (data: T) => Promise<M>,
+  useCache: boolean,
+  prefix?: string
+): Promise<M> => {
   if (!redisInstance || !cacheEnabled) {
     return filler(keyData);
   }
@@ -86,8 +90,8 @@ export const getOrFill = async <T, M>(keyData: T, filler: (data: T) => Promise<M
     return await filler(keyData);
   }
 
-  logger?.debug('Filling cache key: ' + redisKey);
   const acsResponse = await filler(keyData);
+  logger?.debug(`Filling cache key: ${redisKey}`, acsResponse);
   if (acsResponse) {
     if (ttl) {
       await redisInstance.setEx(redisKey, ttl, JSON.stringify(acsResponse));

--- a/packages/acs-client/src/acs/decorators.ts
+++ b/packages/acs-client/src/acs/decorators.ts
@@ -236,7 +236,7 @@ export function access_controlled_service<T extends { new(...args: any): AccessC
 
 export function access_controlled_function<T extends AccessControlledServiceRequest>(
   kwargs: AccessControlledFunctionOptions<T>,
-) {
+): any {
   return function (
     target: (request: T, ...args: any[]) => Promise<any>,
     context: ClassMethodDecoratorContext,

--- a/packages/acs-client/src/acs/interfaces.ts
+++ b/packages/acs-client/src/acs/interfaces.ts
@@ -4,8 +4,10 @@ import {
   Subject,
   DeepPartial
 } from '@restorecommerce/rc-grpc-clients/dist/generated-server/io/restorecommerce/auth.js';
-import { Meta } from '@restorecommerce/rc-grpc-clients/dist/generated-server/io/restorecommerce/meta.js';
-import { FilterOp } from '@restorecommerce/rc-grpc-clients/dist/generated-server/io/restorecommerce/resource_base.js';
+import {
+  FilterOp,
+  Resource,
+} from '@restorecommerce/rc-grpc-clients/dist/generated-server/io/restorecommerce/resource_base.js';
 import {
   Response_Decision,
   ReverseQuery,
@@ -58,14 +60,7 @@ export interface ACSResource {
   property?: string[];
 }
 
-export interface CtxResource {
-  id: string;
-  meta: {
-    created?: Date;
-    modified?: Date;
-    modified_by?: string;
-    owners: Attribute[]; // id owner is mandatory in resource others are optional
-  };
+export interface CtxResource extends Resource {
   [key: string]: any;
 }
 
@@ -145,11 +140,7 @@ export interface AuthZContext {
   security: any;
 }
 
-export interface ResourceData {
-  id: string;
-  meta: Meta;
-  [key: string]: any; // any other fields
-}
+export { CtxResource as ResourceData };
 
 export interface AuthZRequest extends Request<AuthZTarget, AuthZContext> {
   target: AuthZTarget;

--- a/packages/acs-client/src/config.ts
+++ b/packages/acs-client/src/config.ts
@@ -2,8 +2,61 @@ import { createServiceConfig } from '@restorecommerce/service-config';
 // Export cfg Object
 export let cfg: any = createServiceConfig(process.cwd());
 // errors mapped to code and message
-export const errors = cfg.get('errors');
+
+export const errors = {
+  INVALID_CREDENTIALS: {
+    code: 401,
+    message: 'Invalid credentials'
+  },
+  USER_NOT_LOGGED_IN: {
+    code: 401,
+    message: 'User not logged in, please login first!'
+  },
+  ACTION_NOT_ALLOWED: {
+    code: 403,
+    message: 'Action not allowed on this resource'
+  },
+  SYSTEM_ERROR: {
+    code: 500,
+    message: 'System Error!'
+  },
+};
+export type KnownErrors = typeof errors;
+Object.assign(errors, cfg.get('errors'));
+
+export const urns = {
+  entity: 'urn:restorecommerce:acs:names:model:entity',
+  role: 'urn:restorecommerce:acs:names:role',
+  roleScopingEntity: 'urn:restorecommerce:acs:names:roleScopingEntity',
+  roleScopingInstance: 'urn:restorecommerce:acs:names:roleScopingInstance',
+  hierarchicalRoleScoping: 'urn:restorecommerce:acs:names:hierarchicalRoleScoping',
+  unauthenticated_user: 'urn:restorecommerce:acs:names:unauthenticated-user',
+  property: 'urn:restorecommerce:acs:names:model:property',
+  ownerIndicatoryEntity: 'urn:restorecommerce:acs:names:ownerIndicatoryEntity',
+  ownerInstance: 'urn:restorecommerce:acs:names:ownerInstance',
+  subjectID: 'urn:oasis:names:tc:xacml:1.0:subject:subject-id',
+  resourceID: 'urn:oasis:names:tc:xacml:1.0:resource:resource-id',
+  actionID: 'urn:oasis:names:tc:xacml:1.0:action:action-id',
+  action: 'urn:restorecommerce:acs:names:action',
+  operation: 'urn:restorecommerce:acs:names:operation',
+  execute: 'urn:restorecommerce:acs:names:action:execute',
+  permitOverrides: 'urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:permit-overrides',
+  denyOverrides: 'urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides',
+  create: 'urn:restorecommerce:acs:names:action:create',
+  read: 'urn:restorecommerce:acs:names:action:read',
+  modify: 'urn:restorecommerce:acs:names:action:modify',
+  delete: 'urn:restorecommerce:acs:names:action:delete',
+  aclIndicatoryEntity: 'urn:restorecommerce:acs:names:aclIndicatoryEntity',
+  aclInstance: 'urn:restorecommerce:acs:names:aclInstance',
+  skipACL: 'urn:restorecommerce:acs:names:skipACL',
+  maskedProperty: 'urn:restorecommerce:acs:names:obligation:maskedProperty',
+  model: 'urn:restorecommerce:acs:names:model:entity',
+};
+export type KnownUrns = typeof urns;
+Object.assign(urns, cfg.get('authorization:urns'));
 
 export const updateConfig = (config: any) => {
   cfg = config;
+  Object.assign(errors, cfg.get('errors'));
+  Object.assign(urns, cfg.get('authorization:urns'));
 };

--- a/packages/acs-client/src/config.ts
+++ b/packages/acs-client/src/config.ts
@@ -25,6 +25,9 @@ export type KnownErrors = typeof errors;
 Object.assign(errors, cfg.get('errors'));
 
 export const urns = {
+  model: 'urn:restorecommerce:acs:model',
+  user: 'urn:restorecommerce:acs:model:user.User',
+  organization: "urn:restorecommerce:acs:model:organization.Organization",
   entity: 'urn:restorecommerce:acs:names:model:entity',
   role: 'urn:restorecommerce:acs:names:role',
   roleScopingEntity: 'urn:restorecommerce:acs:names:roleScopingEntity',
@@ -50,7 +53,6 @@ export const urns = {
   aclInstance: 'urn:restorecommerce:acs:names:aclInstance',
   skipACL: 'urn:restorecommerce:acs:names:skipACL',
   maskedProperty: 'urn:restorecommerce:acs:names:obligation:maskedProperty',
-  model: 'urn:restorecommerce:acs:names:model:entity',
 };
 export type KnownUrns = typeof urns;
 Object.assign(urns, cfg.get('authorization:urns'));

--- a/packages/acs-client/src/utils.ts
+++ b/packages/acs-client/src/utils.ts
@@ -30,7 +30,7 @@ import { Effect } from '@restorecommerce/rc-grpc-clients/dist/generated-server/i
 export const handleError = (err: string | Error | any): any => {
   let error;
   if (typeof err == 'string') {
-    error = errors[err] || errors.SYSTEM_ERROR;
+    error = (errors as any)[err] ?? errors.SYSTEM_ERROR;
   } else {
     error = errors.SYSTEM_ERROR;
   }
@@ -551,11 +551,8 @@ interface QueryParams {
 }
 
 export const generateOperationStatus = (code?: number, message?: string) => {
-  if (!code) {
-    code = 500; // Internal server error
-  }
   return {
-    code,
+    code: Number.isInteger(code) ? code : 500,
     message
   };
 };

--- a/packages/acs-client/src/utils.ts
+++ b/packages/acs-client/src/utils.ts
@@ -8,12 +8,11 @@ import {
   ResolvedSubject, Obligation
 } from './acs/interfaces.js';
 import { QueryArguments, UserQueryArguments } from './acs/resolver.js';
-import { errors, cfg } from './config.js';
+import { errors, cfg, urns } from './config.js';
 // @ts-expect-error TS7016
 import nodeEval from 'node-eval';
 import logger from './logger.js';
 import { get } from './acs/cache.js';
-import { formatResourceType } from './acs/authz.js';
 import {
   Subject,
   DeepPartial
@@ -36,6 +35,21 @@ export const handleError = (err: string | Error | any): any => {
   }
   return error;
 };
+
+export const notAllowedMessage = (
+  subjectID?: string,
+  resourceName?: string,
+  action?: string,
+  targetScope?: string,
+  decision?: string,
+) => [
+  `Access not allowed for request with`,
+  `subject:${ subjectID || 'undefined' },`,
+  `resource:${ resourceName || 'undefined' },`,
+  `action:${ action || 'undefined' },`,
+  `target_scope:${ targetScope || 'undefined' };`,
+  `the response was ${ decision || 'undefined' }`,
+].join(' ');
 
 const reduceUserScope = (
   hrScope: HierarchicalScope,
@@ -85,12 +99,11 @@ const checkSubjectMatch = (
   let hierarchicalRoleScopingCheck = 'true'; // by default HR scoping check is considered
   let ruleRoleValue: string;
   let ruleRoleScopeEntityName: string;
-  const urns = cfg.get('authorization:urns');
   if (ruleSubjectAttributes?.length === 0) {
     return true;
   }
   for (const attribute of ruleSubjectAttributes) {
-    if (attribute?.id === 'urn:restorecommerce:acs:names:unauthenticated-user' && attribute?.value === 'true') {
+    if (attribute?.id === urns.unauthenticated_user && attribute?.value === 'true') {
       return true;
     }
     if (attribute?.id === urns.roleScopingEntity) {
@@ -192,7 +205,7 @@ const buildQueryFromTarget = (
     if (!reqResources) {
       reqResources = [];
     }
-    if (!_.isArray(reqResources)) {
+    if (!Array.isArray(reqResources)) {
       reqResources = [reqResources];
     }
     const request = {
@@ -233,7 +246,7 @@ const buildQueryFromTarget = (
         }
       } else if (typeof filterId === 'object') { // prebuilt filter
         // handle array
-        if (filterId.filters && _.isArray(filterId.filters)) {
+        if (filterId.filters && Array.isArray(filterId.filters)) {
           filter.push(...filterId.filters);
           // map filter operator if its returned from condition
           if (filterId?.operator) {
@@ -368,7 +381,6 @@ export const buildFilterPermissions = async (
     subject.role_associations ??= [];
   }
 
-  const urns = cfg.get('authorization:urns');
   const query: any = {
     filters: []
   };
@@ -511,7 +523,7 @@ export const buildFilterPermissions = async (
     for (const filter of filterList) {
       query.filters.push(filter);
     }
-    if (_.isArray(filterList) && filterList.length > 0) {
+    if (Array.isArray(filterList) && filterList.length > 0) {
       query.filters.operator = key;
       // override the operator if its returned from rule condition
       if (policy?.filters?.operator) {
@@ -628,6 +640,20 @@ export interface FilterMapResponse {
   customQueryArgs: CustomQueryArgs[];
 }
 
+export const formatResourceType = (type: string, namespacePrefix?: string): string => {
+  // e.g: contact_point -> contact_point.ContactPoint
+  const prefix = type;
+  const suffixArray = type.split('_').map((word) => {
+    return word.charAt(0).toUpperCase() + word.substring(1);
+  });
+  const suffix = suffixArray.join('');
+  if (namespacePrefix) {
+    return `${namespacePrefix}.${prefix}.${suffix}`;
+  } else {
+    return `${prefix}.${suffix}`;
+  }
+};
+
 /**
  * creates resource filters and custom query / arguments for the resource list provided
  * It iterates through each resource and filter the applicable policies and
@@ -670,7 +696,6 @@ export const createResourceFilterMap = async (
       resourceName = resourcenameNameSpace;
     }
     const resourceType = formatResourceType(resourceName, resourceNameSpace);
-    const urns = cfg.get('authorization:urns');
     const resourceValueURN = urns?.model + `:${resourceType}`;
     const resourcePolicies = { policy_sets: [{ policies: [] } as PolicySetRQ] };
     const resourceAttributes = [{ id: urns?.entity, value: resourceValueURN }];
@@ -715,7 +740,7 @@ export const createResourceFilterMap = async (
     );
 
     if (permissionArguments) {
-      if (!_.isArray(permissionArguments.filters)) {
+      if (!Array.isArray(permissionArguments.filters)) {
         permissionArguments.filters = [permissionArguments.filters];
       }
       resourceFilterMap.push({ resource: resourceName, filters: permissionArguments.filters });
@@ -728,23 +753,34 @@ export const createResourceFilterMap = async (
       }
     }
     else if (authzEnforced) {
-      const msg = [
-        `Access not allowed for request with subject:${subjectID},`,
-        `resource:${resourceName}, action:${action}, target_scope:${targetScope};`,
-        `the response was ${Response_Decision.DENY}`
-      ].join(' ');
+      const msg = notAllowedMessage(
+        subjectID,
+        resourceName,
+        action,
+        targetScope,
+        Response_Decision.DENY,
+      );
       const details = `Subject:${subjectID} does not have access to target scope ${targetScope}}`;
       logger?.verbose(msg);
       logger?.verbose('Details:', { details });
       return { decision: Response_Decision.DENY, operation_status: generateOperationStatus(Number(errors.ACTION_NOT_ALLOWED.code), msg) };
     }
     else {
-      logger?.verbose([
-        `The Access response was ${Response_Decision.DENY} for a request from subject:${subjectID}`,
-        `resource:${resourceName}, action:${action}, target_scope:${targetScope}`,
-        `but since ACS enforcement config is disabled overriding the ACS result`,
-      ].join(' '));
-      return { decision: Response_Decision.PERMIT, operation_status: { code: 200, message: 'success' } };
+      const msg = notAllowedMessage(
+        subjectID,
+        resourceName,
+        action,
+        targetScope,
+        Response_Decision.DENY,
+      );
+      logger?.verbose(msg);
+      return {
+        decision: Response_Decision.PERMIT,
+        operation_status: {
+          code: 200,
+          message: 'success',
+        }
+      };
     }
   }
   return {
@@ -762,7 +798,6 @@ export const createResourceFilterMap = async (
  */
 export const mapResourceURNObligationProperties = (obligations: Attribute[]): Obligation[] => {
   const mappedResourceObligation: Obligation[] = [];
-  const urns = cfg.get('authorization:urns');
   if (obligations?.length > 0) {
     for (const obligationObj of obligations) {
       if (obligationObj?.id === urns.entity && obligationObj?.value) {

--- a/packages/acs-client/src/utils.ts
+++ b/packages/acs-client/src/utils.ts
@@ -1,6 +1,4 @@
 import lodash from 'lodash';
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-require('deepdash')(lodash);
 export const _ = lodash;
 import {
   PolicySetRQ, PolicySetRQResponse, AttributeTarget, HierarchicalScope,

--- a/packages/acs-client/test/acs.spec.test.ts
+++ b/packages/acs-client/test/acs.spec.test.ts
@@ -250,7 +250,7 @@ const updateMetaData = (resourceList: Array<any>): Array<CtxResource> => {
 const PROTO_PATH: string = 'io/restorecommerce/access_control.proto';
 const PKG_NAME: string = 'io.restorecommerce.access_control';
 const SERVICE_NAME: string = 'AccessControlService';
-const mockServer = new GrpcMockServer('localhost:50061');
+const mockServer = new GrpcMockServer('localhost:50161');
 
 const startGrpcMockServer = async () => {
   // create mock implementation based on the method name and output

--- a/packages/acs-client/test/acs_decorators.spec.test.ts
+++ b/packages/acs-client/test/acs_decorators.spec.test.ts
@@ -5,7 +5,8 @@ import { it, describe, beforeAll, afterAll, beforeEach, afterEach } from 'vitest
 import {
   ResourceListResponse,
   ReadRequest,
-  ResourceList
+  ResourceList,
+  DeepPartial
 } from '@restorecommerce/rc-grpc-clients/dist/generated-server/io/restorecommerce/resource_base';
 import {
   ContactPointList,

--- a/packages/acs-client/test/acs_decorators.spec.test.ts
+++ b/packages/acs-client/test/acs_decorators.spec.test.ts
@@ -1,0 +1,647 @@
+import * as should from 'should';
+import { GrpcMockServer } from '@alenon/grpc-mock-server';
+import { CallContext } from 'nice-grpc';
+import { it, describe, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
+import {
+  Response_Decision
+} from '@restorecommerce/rc-grpc-clients/dist/generated-server/io/restorecommerce/access_control';
+import {
+  ResourceListResponse,
+  DeleteRequest,
+  DeleteResponse,
+  ReadRequest,
+  ResourceList
+} from '@restorecommerce/rc-grpc-clients/dist/generated-server/io/restorecommerce/resource_base';
+import {
+  ContactPointList,
+  ContactPointListResponse
+} from '@restorecommerce/rc-grpc-clients/dist/generated-server/io/restorecommerce/contact_point';
+import { ServiceConfig } from '@restorecommerce/service-config';
+import { Logger } from '@restorecommerce/logger';
+import { Subject } from '@restorecommerce/rc-grpc-clients/dist/generated-server/io/restorecommerce/auth';
+import { accessRequest } from '../src/acs/resolver';
+import { flushCache, initializeCache } from '../src/acs/cache';
+import {
+  AuthZAction,
+  PolicySetRQResponse,
+  Operation,
+  ACSClientContext,
+  CtxResource,
+} from '../src/acs/interfaces';
+import logger from '../src/logger';
+import {
+  access_controlled_function,
+  access_controlled_service,
+  AccessControllableService,
+  cfg,
+  DefaultACSClientContextFactory,
+  DefaultResourceFactoryInstance,
+} from '../src';
+import {
+  denyRule,
+  expectedError,
+  mockServices,
+  meta,
+  operation_status,
+  permitRuleNoHrs,
+  permitRuleOrgScope,
+  permitRuleUserScope,
+  PolicySetRQFactory,
+  status,
+} from './mock_server';
+
+const encode = (object: any): any => {
+  if (Array.isArray(object)) {
+    return object.map(encode);
+  } else {
+    return {
+      value: Buffer.from(JSON.stringify(object))
+    };
+  }
+};
+
+let mocking: GrpcMockServer[];
+const start = async (): Promise<void> => {
+  mocking = await mockServices(cfg.get('client'));
+};
+
+const stop = async (): Promise<void> => {
+  mocking?.forEach(mock => mock?.stop());
+};
+
+@access_controlled_service
+class DecoratedTestService<
+  I extends ResourceList,
+  O extends ResourceListResponse
+> implements AccessControllableService {
+  
+  constructor(
+    public readonly name: string,
+    public mock_data?: I['items'],
+    cfg?: ServiceConfig,
+    logger?: Logger,
+  ) {}
+
+  public async get(
+    ids: string[],
+    subject?: Subject,
+    context?: CallContext,
+    bypassACS = false,
+  ): Promise<O> {
+    return {
+      items: this.mock_data?.map(
+        payload => ({
+          payload,
+          status,
+        })
+      ),
+      total_count: 
+      operation_status,
+    } as O;
+  }
+
+  @access_controlled_function({
+    action: AuthZAction.CREATE,
+    operation: Operation.isAllowed,
+    database: 'arangoDB',
+    useCache: true,
+  })
+  public async create(
+    request: I,
+    context?: CallContext,
+  ): Promise<O> {
+    return {
+      items: request.items?.map(
+        payload => ({
+          payload,
+          status,
+        }),
+      ),
+      total_count: request.items?.length,
+      operation_status,
+    } as O;
+  }
+
+  @access_controlled_function({
+    action: AuthZAction.READ,
+    operation: Operation.whatIsAllowed,
+    database: 'arangoDB',
+    useCache: true,
+  })
+  public async read(
+    request: ReadRequest,
+    context?: CallContext,
+  ): Promise<O> {
+    return {
+      items: this.mock_data?.map(
+        payload => ({
+          payload,
+          status,
+        })
+      ),
+      total_count: 
+      operation_status,
+    } as O;
+  }
+
+  @access_controlled_function({
+    action: AuthZAction.MODIFY,
+    operation: Operation.isAllowed,
+    database: 'arangoDB',
+    useCache: true,
+  })
+  public async update(
+    request: ResourceList,
+    context?: CallContext,
+  ): Promise<O> {
+    return {
+      items: request.items?.map(
+        payload => ({
+          payload,
+          status,
+        }),
+      ),
+      total_count: request.items?.length,
+      operation_status,
+    } as O;
+  }
+
+  @access_controlled_function({
+    action: AuthZAction.MODIFY,
+    operation: Operation.isAllowed,
+    database: 'arangoDB',
+    useCache: true,
+  })
+  public async upsert(
+    request: I,
+    context?: CallContext,
+  ): Promise<O> {
+    return {
+      items: request.items?.map(
+        payload => ({
+          payload,
+          status,
+        }),
+      ),
+      total_count: request.items?.length,
+      operation_status,
+    } as O;
+  }
+
+  @access_controlled_function({
+    action: AuthZAction.DELETE,
+    operation: Operation.isAllowed,
+    database: 'arangoDB',
+    useCache: true,
+  })
+  public async delete(
+    request: DeleteRequest,
+    context?: CallContext,
+  ): Promise<DeleteResponse> {
+    return {
+      status: request.ids?.map(
+        id => ({
+          ...status,
+          id,
+        })
+      ),
+      operation_status
+    };
+  }
+};
+const decoratedTestService = new DecoratedTestService<ContactPointList, ContactPointListResponse>(
+  'contact_point',
+  [ // mock_data
+    {
+      id: 'test_id',
+      name: 'Test',
+      description: 'This is a test description',
+      meta,
+    },
+  ],
+  cfg,
+  logger,
+);
+
+describe('Testing acs-client decorators', () => {
+  beforeAll(async () => {
+    const cacheEnabled = process.env.CACHE_ENABLED;
+    if (cacheEnabled && cacheEnabled.toLowerCase() === 'true') {
+      await initializeCache();
+    }
+    await start();
+  }, 60000);
+
+  afterAll(async () => {
+    await stop();
+    const cacheEnabled = process.env.CACHE_ENABLED;
+    if (cacheEnabled && cacheEnabled.toLowerCase() === 'true') {
+      await flushCache();
+    }
+  });
+
+  beforeEach(async () => {
+    await flushCache('test_user_id:');
+  });
+
+  afterEach(async () => {
+  });
+
+  describe('Decorated CRUD Service', () => {
+    it('Should DENY creating Test resource with unauthenticated context', async () => {
+      // test resrouce to be created
+      const request = ContactPointList.fromPartial({
+        items: [{
+          id: 'test_id',
+          name: 'Test',
+          description: 'This is a test description',
+          // meta is auto resolved by injects_meta_data()!
+        }],
+        subject: {
+          id: 'test_user_id',
+          scope: 'targetScope',
+          token: 'unauthenticated_token',
+          unauthenticated: true,
+        }
+      });
+
+      const response = await decoratedTestService.create(request);
+      should.equal(response.operation_status?.code, 403);
+      should.equal(
+        response.operation_status?.message,
+        expectedError,
+      );
+    });
+
+    it('Should PERMIT creating Test resource with valid Org scope matching Ctx', async () => {
+      // test resource to be created
+      const request = ContactPointList.fromPartial({
+        items: [{
+          id: 'test_id',
+          name: 'Test',
+          description: 'This is a test description',
+          // meta is auto resolved by injects_meta_data()!
+        }],
+        subject: {
+          id: 'test_user_id',
+          scope: 'targetScope',
+          token: 'valid_token',
+        }
+      });
+
+      const response = await decoratedTestService.create(request);
+      should.equal(response.operation_status?.code, 200);
+      should.equal(response.operation_status?.message, 'success');
+    });
+
+    it('Should PERMIT creating Test resource with valid User scope matching Ctx', async () => {
+      // test resource to be created
+      const request = ContactPointList.fromPartial({
+        items: [{
+          id: 'test_id',
+          name: 'Test',
+          description: 'This is a test description',
+          // meta is auto resolved by injects_meta_data()!
+        }],
+        subject: {
+          id: 'test_user_id',
+          // scope: 'targetScope',
+          token: 'valid_token',
+        }
+      });
+
+      const response = await decoratedTestService.create(request);
+      should.equal(response.operation_status?.code, 200);
+      should.equal(response.operation_status?.message, 'success');
+    });
+
+    it('Should DENY reading Test resource (DENY rule)', async () => {
+      // PolicySet contains DENY rule
+      PolicySetRQFactory.rules = [denyRule];
+      const request = ReadRequest.fromPartial({
+        filters: [],
+      });
+
+      const response = await decoratedTestService.read(request);
+      should.equal(response.operation_status?.code, 403);
+      should.equal(
+        response.operation_status?.message,
+        [
+          'Access not allowed for request with subject:test_user_id,',
+          'resource:test-resource, action:READ, target_scope:targetScope; the response was DENY',
+        ].join(' ')
+      );
+    });
+
+    it(
+      [
+        'Should PERMIT reading Test resource (PERMIT rule with org scoping) and verify input filter',
+        'is extended to enforce applicable policies'
+      ].join(' '),
+      async () => {
+        // PolicySet contains PERMIT rule
+        PolicySetRQFactory.rules = [permitRuleOrgScope];
+        const request = ReadRequest.fromPartial({
+          filters: [],
+          subject: {
+            id: 'test_user_id',
+            scope: 'targetScope',
+            token: 'valid_token',
+          }
+        });
+  
+        const response = await decoratedTestService.read(request);
+        /**
+         * hierarchical_scopes: [{
+            id: 'targetScope',
+            role: 'test-role',
+            children: [{
+              id: 'targetSubScope'
+            }]
+          }]
+         */
+        should.equal(response.operation_status?.code, 200);
+        should.equal(response.operation_status?.message, 'success');
+        // verify input is modified to enforce the applicapble poilicies
+        const filterParamKey = cfg.get('authorization:filterParamKey')[0].value;
+        const expectedFilterResponse = [{
+          field: filterParamKey,
+          operation: 'eq',
+          value: 'targetScope'
+        }, {
+          field: filterParamKey,
+          operation: 'eq',
+          value: 'targetSubScope'
+        }];
+        const filterEntityMap = request.filters;
+        const filters = filterEntityMap?.[0].filters;
+        should.deepEqual(filters?.[0]?.filters?.[0], expectedFilterResponse[0]);
+        should.deepEqual(filters?.[0]?.filters?.[1], expectedFilterResponse[1]);
+      }
+    );
+
+    it(
+      'Should DENY reading Test resource (PERMIT rule) with invalid user target scope',
+      async () => {
+        // PolicySet contains PERMIT rule
+        PolicySetRQFactory.rules = [permitRuleUserScope];
+        const request = ReadRequest.fromPartial({
+          filters: [],
+          subject: {
+            id: 'test_user_id',
+            scope: 'invalidScope',
+            token: 'valid_token',
+          }
+        });
+  
+        const response = await decoratedTestService.read(request);
+        should.equal(response.operation_status?.code, 403);
+        should.equal(
+          response.operation_status?.message,
+          'Access not allowed for request with subject:test_user_id, ' +
+          'resource:test-resource, action:READ, target_scope:invalidUserId; the response was DENY',
+        );
+      }
+    );
+
+    it(
+      'Should PERMIT reading Test resource (PERMIT rule User scope) without target scope and verify input filter ' +
+      'is extended to enforce applicable policies for matching user role',
+      async () => {
+        // PolicySet contains PERMIT rule
+        PolicySetRQFactory.rules = [permitRuleUserScope];
+        const request = ReadRequest.fromPartial({
+          filters: [],
+          subject: {
+            id: 'test_user_id',
+            // scope: 'targetScope',
+            token: 'valid_token',
+          }
+        });
+        const response = await decoratedTestService.read(request);
+
+        should.equal(response.operation_status?.code, 200);
+        should.equal(response.operation_status?.message, 'success');
+        // verify input is modified to enforce the applicapble poilicies
+        const filterParamKey = cfg.get('authorization:filterParamKey')[1].value;
+        const expectedFilterResponse = [{
+          field: filterParamKey,
+          operation: 'eq',
+          value: 'test_user_id'
+        }];
+        const filterEntityMap = request.filters;
+        const filters = filterEntityMap?.[0].filters;
+        should.deepEqual(filters?.[0]?.filters?.[0], expectedFilterResponse[0]);
+      }
+    );
+
+    it(
+      'Should PERMIT reading Test resource (PERMIT rule Org Scope and User scope) without target scope and ' +
+      'verify input filter is extended to enforce applicable policies for matching user role',
+      async () => {
+        // PolicySet contains PERMIT rule for OrgScoping and UserScoping entity
+        PolicySetRQFactory.rules = [permitRuleOrgScope, permitRuleUserScope];
+        const request = ReadRequest.fromPartial({
+          filters: [],
+          subject: {
+            id: 'test_user_id',
+            // scope: 'targetScope',
+            token: 'valid_token',
+          }
+        });
+        const response = await decoratedTestService.read(request);
+
+        should.equal(response.operation_status?.code, 200);
+        should.equal(response.operation_status?.message, 'success');
+        // verify input is modified to enforce the applicapble both Org and User poilicy
+        const orgFilterKey = cfg.get('authorization:filterParamKey')[0].value;
+        const userFilterKey = cfg.get('authorization:filterParamKey')[1].value;
+        const expectedFilterResponse = [
+          { field: orgFilterKey, operation: 'eq', value: 'targetScope' },
+          { field: orgFilterKey, operation: 'eq', value: 'targetSubScope' },
+          { field: userFilterKey, operation: 'eq', value: 'test_user_id' },
+        ];
+        const filterEntityMap = request.filters;
+        const filters = filterEntityMap?.[0].filters;
+        should.deepEqual(filters?.[0]?.filters?.[0], expectedFilterResponse[0]);
+      }
+    );
+
+    it(
+      'Should PERMIT reading Test resource (PERMIT rule with org scope) with HR scoping enabled and verify input filter ' +
+      'is extended to enforce applicable policies',
+      async () => {
+        // PolicySet contains PERMIT rule
+        PolicySetRQFactory.rules = [permitRuleOrgScope];
+        const request = ReadRequest.fromPartial({
+          filters: [],
+          subject: {
+            id: 'test_user_id',
+            scope: 'targetSubScope',
+            token: 'valid_token',
+          }
+        });
+        const response = await decoratedTestService.read(request);
+
+        should.equal(response.operation_status?.code, 200);
+        should.equal(response.operation_status?.message, 'success');
+        // verify input is modified to enforce the applicapble poilicies
+        const filterParamKey = cfg.get('authorization:filterParamKey')[0].value;
+        const expectedFilterResponse = { field: filterParamKey, operation: 'eq', value: 'targetSubScope' };
+        const filters = request.filters?.[0].filters;
+        should.deepEqual(filters?.[0]?.filters?.[0], expectedFilterResponse);
+      }
+    );
+
+    it(
+      'Should PERMIT reading Test resource when no scope is provided (PERMIT rule with org scope) with HR scoping ' +
+      'enabled and verify since no scope is provided all applicable HR scope instances are returned',
+      async () => {
+        // PolicySet contains PERMIT rule
+        PolicySetRQFactory.rules = [permitRuleOrgScope];
+
+        // test resource to be read of type 'ReadRequest'
+        const resources: CtxResource[] = [{
+          id: 'test_id',
+          meta: {
+            owners: []
+          }
+        }];
+
+        // user ctx data updated in session
+        const subject = {
+          id: 'test_user_id',
+          token: 'valid_token',
+          role_associations: [
+            {
+              role: 'test-role',
+              attributes: [
+                {
+                  id: 'urn:restorecommerce:acs:names:roleScopingEntity',
+                  value: 'urn:test:acs:model:organization.Organization',
+                  attributes: [{
+                    id: 'urn:restorecommerce:acs:names:roleScopingInstance',
+                    value: 'targetScope'
+                  }]
+                }
+              ]
+            }
+          ],
+          hierarchical_scopes: [
+            {
+              id: 'targetScope',
+              role: 'test-role',
+              children: [{
+                id: 'targetSubScope'
+              }]
+            }
+          ]
+        };
+
+        const ctx: ACSClientContext = {
+          subject,
+          resources,
+        };
+
+        // call accessRequest(), the response is from mock ACS
+        const readResponse = await accessRequest(
+          subject,
+          [{ resource: 'Test', id: resources[0].id }],
+          AuthZAction.READ,
+          ctx, { operation: Operation.whatIsAllowed, database: 'postgres' }
+        ) as PolicySetRQResponse;
+
+        should.equal(readResponse.decision, Response_Decision.PERMIT);
+        should.equal(readResponse.operation_status?.code, 200);
+        should.equal(readResponse.operation_status?.message, 'success');
+        // verify input is modified to enforce the applicapble poilicies
+        const filterParamKey = cfg.get('authorization:filterParamKey')[0].value;
+        const expectedFilterResponse = [{
+          field: filterParamKey,
+          operation: 'eq',
+          value: 'targetScope'
+        }, {
+          field: filterParamKey,
+          operation: 'eq',
+          value: 'targetSubScope'
+        }];
+        should.equal(readResponse.filters?.[0]?.resource, 'Test');
+        const filters = readResponse.filters?.[0].filters;
+        should.deepEqual(filters?.[0]?.filters?.[0], expectedFilterResponse[0]);
+        should.deepEqual(filters?.[0]?.filters?.[1], expectedFilterResponse[1]);
+      }
+    );
+
+    it(
+      'Should DENY reading Test resource (PERMIT rule) with HR scoping disabled',
+      async () => {
+        const cacheEnabled = process.env.CACHE_ENABLED;
+        if (cacheEnabled && cacheEnabled.toLowerCase() === 'true') {
+          await flushCache();
+        }
+        // PolicySet contains PERMIT rule
+        PolicySetRQFactory.rules = [permitRuleNoHrs];
+
+        // test resource to be read of type 'ReadRequest'
+        const resources: CtxResource[] = [{
+          id: 'test_id',
+          meta: {
+            owners: []
+          }
+        }];
+
+        // user ctx data updated in session
+        const subject = {
+          id: 'test_user_id',
+          scope: 'targetSubScope',
+          token: 'invalid_token',
+          role_associations: [
+            {
+              role: 'test-role',
+              attributes: [
+                {
+                  id: 'urn:restorecommerce:acs:names:roleScopingEntity',
+                  value: 'urn:test:acs:model:organization.Organization',
+                  attributes: [{
+                    id: 'urn:restorecommerce:acs:names:roleScopingInstance',
+                    value: 'targetScope'
+                  }]
+                }
+              ]
+            }
+          ],
+          hierarchical_scopes: [
+            {
+              id: 'targetScope',
+              role: 'test-role',
+              children: [{
+                id: 'targetSubScope'
+              }]
+            }
+          ]
+        };
+
+        const ctx: ACSClientContext = {
+          subject,
+          resources,
+        };
+
+        // call accessRequest(), the response is from mock ACS
+        const readResponse = await accessRequest(
+          subject,
+          [{ resource: 'Test', id: resources[0].id }],
+          AuthZAction.READ,
+          ctx, { operation: Operation.whatIsAllowed, database: 'postgres' }
+        ) as PolicySetRQResponse;
+
+        should.equal(readResponse.decision, Response_Decision.DENY);
+        should.equal(readResponse.operation_status?.code, 403);
+        should.equal(
+          readResponse.operation_status?.message,
+          'Access not allowed for request with subject:test_user_id, ' +
+          'resource:Test, action:READ, target_scope:targetSubScope; the response was DENY'
+        );
+      }
+    );
+  });
+});

--- a/packages/acs-client/test/acs_multiple_entities.spec.test.ts
+++ b/packages/acs-client/test/acs_multiple_entities.spec.test.ts
@@ -74,7 +74,7 @@ const updateMetaData = (resourceList: Array<any>): Array<CtxResource> => {
 const PROTO_PATH: string = 'io/restorecommerce/access_control.proto';
 const PKG_NAME: string = 'io.restorecommerce.access_control';
 const SERVICE_NAME: string = 'AccessControlService';
-const mockServer = new GrpcMockServer('localhost:50061');
+const mockServer = new GrpcMockServer('localhost:50161');
 
 const startGrpcMockServer = async () => {
   // create mock implementation based on the method name and output

--- a/packages/acs-client/test/mock_server.ts
+++ b/packages/acs-client/test/mock_server.ts
@@ -1,0 +1,363 @@
+import { GrpcMockServer } from '@alenon/grpc-mock-server';
+import {
+  RedisClientType,
+  createClient as RedisCreateClient
+} from 'redis';
+import { Effect } from '@restorecommerce/rc-grpc-clients/dist/generated-server/io/restorecommerce/rule';
+import {
+  OperationStatus,
+  Status
+} from '@restorecommerce/rc-grpc-clients/dist/generated-server/io/restorecommerce/status';
+import { Meta } from '@restorecommerce/rc-grpc-clients/dist/generated-server/io/restorecommerce/meta';
+import { UserResponse } from '@restorecommerce/rc-grpc-clients/dist/generated-server/io/restorecommerce/user';
+import {
+  Response_Decision
+} from '@restorecommerce/rc-grpc-clients/dist/generated-server/io/restorecommerce/access_control';
+import logger from '../src/logger';
+import {
+  RuleRQ,
+} from '../src/acs/interfaces';
+import {
+  cfg,
+  urns as defaultUrns,
+} from '../src';
+import { HierarchicalScope } from '@restorecommerce/rc-grpc-clients/dist/generated-server/io/restorecommerce/auth';
+
+export const urns = {
+  ...defaultUrns,
+  user: 'urn:test:acs:model:user.User',
+  model: 'urn:test:acs:model',
+  orgScope: 'urn:test:acs:model:organization.Organization',
+  organization: 'urn:test:acs:model:organization.Organization',
+  contact_point: 'urn:test:acs:model:contactPoint.ContactPoint',
+};
+Object.assign(urns, cfg.get('authorization:urns'));
+
+export const test_user_id = 'test_user_id';
+export const target_scope = 'targetScope';
+
+export const meta: Meta = {
+  owners: [
+    {
+      id: urns.ownerIndicatoryEntity,
+      value: urns.organization,
+      attributes: [{
+        id: urns.ownerInstance,
+        value: target_scope
+      }]
+    },
+    {
+      id: urns.ownerIndicatoryEntity,
+      value: urns.user,
+      attributes: [{
+        id: urns.ownerInstance,
+        value: test_user_id
+      }]
+    },
+  ]
+};
+
+export const status: Status = {
+  code: 200,
+  message: 'success',
+};
+
+export const operation_status: OperationStatus = {
+  code: 200,
+  message: 'success'
+};
+
+const hierarchicalScopes: Record<string, HierarchicalScope[]> = {
+  'valid-token': [
+    {
+      id: 'targetScope',
+      role: 'user-role',
+      children: [
+        {
+          id: 'targetSubScope',
+        }
+      ]
+    }
+  ]
+};
+
+export const users: Record<string, UserResponse> = {
+  'valid-token': {
+    payload: {
+      id: test_user_id,
+      role_associations: [
+        {
+          role: 'test-role',
+          attributes: [
+            {
+              id: urns.roleScopingEntity,
+              value: urns.organization,
+              attributes: [{
+                id: urns.roleScopingInstance,
+                value: 'targetScope'
+              }]
+            }
+          ]
+        },
+        {
+          role: 'user-role',
+          attributes: [
+            {
+              id: urns.roleScopingEntity,
+              value: urns.user,
+              attributes: [{
+                id: urns.roleScopingInstance,
+                value: 'test_user_id'
+              }]
+            }
+          ]
+        }
+      ],
+      active: true,
+      tokens: [
+        
+      ],
+      meta,
+    },
+    status,
+  },
+};
+
+export const permitRuleOrgScope: RuleRQ = {
+  id: 'permit_rule_id',
+  target: {
+    actions: [],
+    resources: [{
+      id: urns.entity,
+      value: urns.contact_point,
+    }],
+    subjects: [
+      {
+        id: urns.role,
+        value: 'test-role'
+      },
+      {
+        id: urns.roleScopingEntity,
+        value: urns.organization,
+      },
+      {
+        id: urns.hierarchicalRoleScoping,
+        value: 'true'
+      }]
+  },
+  effect: Effect.PERMIT
+};
+
+export const permitRuleUserScope: RuleRQ = {
+  id: 'permit_rule_id',
+  target: {
+    actions: [],
+    resources: [{
+      id: urns.entity,
+      value: urns.contact_point,
+    }],
+    subjects: [
+      {
+        id: urns.role,
+        value: 'user-role'
+      },
+      {
+        id: urns.roleScopingEntity,
+        value: urns.user,
+      },
+      {
+        id: urns.hierarchicalRoleScoping,
+        value: 'false',
+      }]
+  },
+  effect: Effect.PERMIT
+};
+
+export const permitRuleNoHrs: RuleRQ = {
+  id: 'no_hrs_permit_rule_id',
+  target: {
+    actions: [],
+    resources: [{
+      id: urns.entity,
+      value: urns.contact_point,
+    }],
+    subjects: [
+      {
+        id: urns.role,
+        value: 'test-role'
+      },
+      {
+        id: urns.roleScopingEntity,
+        value: urns.organization,
+      },
+      {
+        id: urns.hierarchicalRoleScoping,
+        value: 'false',
+      }]
+  },
+  effect: Effect.PERMIT
+};
+
+export const denyRule: RuleRQ = {
+  id: 'deny_rule_id',
+  target: {
+    actions: [],
+    resources: [{
+      id: urns.entity,
+      value: urns.contact_point,
+    }],
+    subjects: [{
+      id: urns.role,
+      value: 'test-role'
+    }],
+  },
+  effect: Effect.DENY
+};
+
+export const PolicySetRQFactory = new class {
+  rules: RuleRQ[] = [];
+  combiningAlgorithm = urns.permitOverrides;
+
+  public get() {
+    return {
+      policy_sets: [
+        {
+          combining_algorithm: urns.permitOverrides,
+          id: 'test_policy_set_id',
+          policies: [
+            {
+              combining_algorithm: this.combiningAlgorithm,
+              id: 'test_policy_id',
+              target: {
+                actions: [],
+                resources: [{
+                  id: urns.entity,
+                  value: urns.contact_point,
+                }],
+                subjects: []
+              },
+              effect: Effect.PERMIT,
+              rules: this.rules,
+              has_rules: true
+            }
+          ]
+        }
+      ],
+      operation_status
+    };
+  }
+}
+
+export const expectedError = [
+  'Access not allowed for request with subject:undefined,',
+  'resource:Test, action:CREATE, target_scope:targetSubScope; the response was DENY'
+].join(' ')
+
+export const implementations = {
+  'acs-srv': {
+    isAllowed: (call: any, callback: any) => {
+      const token = JSON.parse(call?.request?.context?.subject?.value?.toString())?.token;
+      switch (token) {
+        case 'valid_token':
+          callback(
+            null,
+            {
+              decision: Response_Decision.PERMIT,
+              operation_status: {
+                code: 200,
+                message: 'success'
+              }
+            }
+          );
+          break;
+        default:
+          callback(
+            null,
+            {
+              decision: Response_Decision.DENY,
+              operation_status: {
+                code: 403,
+                message: expectedError,
+              }
+            }
+          );
+          break;
+      }
+    },
+    whatIsAllowed: (call: any, callback: any) => {
+      callback(null, PolicySetRQFactory.get());
+    },
+  },
+  user: {
+    findByToken: (
+      call: any,
+      callback: (error: any, response: UserResponse) => void,
+    ) => {
+      getRedisInstance().then(
+        async client => {
+          const subject = users[call?.request?.token] ?? {
+            status: {
+              code: 404,
+              message: 'User not found!'
+            }
+          };
+          if (subject?.payload) {
+            await client.set(
+              `cache:${ subject.payload?.id }:subject`,
+              JSON.stringify(subject.payload),
+            );
+            await client.set(
+              `cache:${ subject.payload?.id }:hrScopes`,
+              JSON.stringify(hierarchicalScopes[call.request.token]),
+            );
+          }
+          return subject;
+        },
+      ).then(
+        subject => callback(null, subject),
+        err => {
+          const { code, message, details, stack } = err;
+          logger.error('Redis Client Error',  { code, message, details, stack, err });
+        },
+      );
+    }
+  },
+};
+
+let redisClient: RedisClientType;
+export async function getRedisInstance() {
+  if (redisClient) {
+    return redisClient;
+  }
+  const redisConfig = cfg.get('redis');
+  redisConfig.database = cfg.get('redis:db-indexes:db-subject');
+  redisClient = RedisCreateClient(redisConfig);
+  redisClient.on('error', (err: any) => {
+    const { code, message, details, stack } = err;
+    logger.error('Redis Client Error', { code, message, details, stack, err });
+  });
+  await redisClient.connect();
+  return redisClient;
+}
+
+export async function mockServices(configs: { [key: string]: any }) {
+  return await Promise.all(Object.entries(configs).map(async ([name, config]) => { 
+    if (!config?.mock) {
+      return;
+    }
+
+    if (!implementations[name]) {
+      throw new Error(`No mocking implementation for ${name} in mocks.ts!`);
+    }
+
+    return await new GrpcMockServer(
+      config.address,
+    ).addService(
+      config.mock.protoPath,
+      config.mock.packageName,
+      config.mock.serviceName,
+      implementations[name],
+      config.mock.protoLoadOptions,
+    ).start();
+  }).filter(m => !!m)) as GrpcMockServer[];
+};

--- a/packages/acs-client/tsconfig.json
+++ b/packages/acs-client/tsconfig.json
@@ -2,5 +2,8 @@
   "extends": "./tsconfig-base.json",
   "include": [
     "./src/**/*.ts"
-  ]
+  ],
+  "compilerOptions": {
+    "experimentalDecorators": true
+  }
 }

--- a/packages/chassis-srv/src/microservice/transport/provider/grpc/index.ts
+++ b/packages/chassis-srv/src/microservice/transport/provider/grpc/index.ts
@@ -1,7 +1,6 @@
 import {isNullish} from 'remeda';
 import { type Logger } from '@restorecommerce/logger';
-import type { Server as GRPCServer, ServiceImplementation } from 'nice-grpc';
-import type { CompatServiceDefinition } from 'nice-grpc/lib/service-definitions';
+import type { Server as GRPCServer, ServiceImplementation, CompatServiceDefinition } from 'nice-grpc';
 import { createServer } from 'nice-grpc';
 import { loggingMiddleware, metaMiddleware, tracingMiddleware, WithRequestID } from './middlewares.js';
 

--- a/packages/protos/io/restorecommerce/notification.proto
+++ b/packages/protos/io/restorecommerce/notification.proto
@@ -52,4 +52,5 @@ message Notification {
   }
   optional string subject_template = 8;
   optional string body_template = 9;
+  optional bool active = 10;
 }

--- a/packages/resource-base-interface/package.json
+++ b/packages/resource-base-interface/package.json
@@ -41,7 +41,7 @@
     "npm-run-all": "^4.1.5",
     "rimraf": "^6.0.1",
     "should": "^13.2.3",
-    "typescript": "^5.6.3",
+    "typescript": "^5.9.2",
     "vitest": "^3.2.4"
   },
   "scripts": {

--- a/packages/resource-base-interface/src/experimental/AccessControlledServiceBase.ts
+++ b/packages/resource-base-interface/src/experimental/AccessControlledServiceBase.ts
@@ -9,8 +9,8 @@ import {
   ACSClientContext,
   AuthZAction,
   DefaultACSClientContextFactory,
+  DefaultResourceFactoryInstance,
   Operation,
-  ResourceFactory,
   access_controlled_function,
   access_controlled_service,
   injects_meta_data,
@@ -56,19 +56,6 @@ export const ACSContextFactory = async <O extends ResourceListResponse, I extend
     ],
   };
 };
-
-export const DefaultResourceFactory = <T extends ResourceList>(
-  ...resourceNames: string[]
-): ResourceFactory<T> => async (
-  self: any,
-  request: T,
-  context?: CallContext,
-) => (resourceNames?.length ? resourceNames : [self.name])?.map(
-  resourceName => ({
-    resource: resourceName,
-    id: request.items?.map((item: any) => item.id)
-  })
-);
 
 export const AccessControlledServiceBaseOperationStatusCodes = {
   ...ServiceBaseOperationStatusCodes,
@@ -245,7 +232,7 @@ export class AccessControlledServiceBase<O extends ResourceListResponse, I exten
     context?: CallContext,
     bypassACS = false,
   ): Promise<DeepPartial<O>> {
-    ids = [...new Set(ids)].filter(id => id);
+    ids = Array.from(new Set(ids)).filter(id => id);
     if (ids.length > 1000) {
       throw this.operationStatusCodes.LIMIT_EXHAUSTED;
     }
@@ -284,7 +271,7 @@ export class AccessControlledServiceBase<O extends ResourceListResponse, I exten
     action: AuthZAction.CREATE,
     operation: Operation.isAllowed,
     context: ACSContextFactory<O, I>,
-    resource: DefaultResourceFactory(),
+    resource: DefaultResourceFactoryInstance,
     database: 'arangoDB',
     useCache: true,
   })
@@ -299,7 +286,7 @@ export class AccessControlledServiceBase<O extends ResourceListResponse, I exten
     action: AuthZAction.READ,
     operation: Operation.whatIsAllowed,
     context: DefaultACSClientContextFactory,
-    resource: DefaultResourceFactory(),
+    resource: DefaultResourceFactoryInstance,
     database: 'arangoDB',
     useCache: true,
   })
@@ -316,7 +303,7 @@ export class AccessControlledServiceBase<O extends ResourceListResponse, I exten
     action: AuthZAction.MODIFY,
     operation: Operation.isAllowed,
     context: ACSContextFactory<O, I>,
-    resource: DefaultResourceFactory(),
+    resource: DefaultResourceFactoryInstance,
     database: 'arangoDB',
     useCache: true,
   })
@@ -333,7 +320,7 @@ export class AccessControlledServiceBase<O extends ResourceListResponse, I exten
     action: AuthZAction.MODIFY,
     operation: Operation.isAllowed,
     context: ACSContextFactory<O, I>,
-    resource: DefaultResourceFactory(),
+    resource: DefaultResourceFactoryInstance,
     database: 'arangoDB',
     useCache: true,
   })
@@ -349,7 +336,7 @@ export class AccessControlledServiceBase<O extends ResourceListResponse, I exten
     action: AuthZAction.DELETE,
     operation: Operation.isAllowed,
     context: ACSContextFactory<O, I>,
-    resource: DefaultResourceFactory(),
+    resource: DefaultResourceFactoryInstance,
     database: 'arangoDB',
     useCache: true,
   })

--- a/packages/resource-base-interface/src/experimental/WorkerBase.ts
+++ b/packages/resource-base-interface/src/experimental/WorkerBase.ts
@@ -1,5 +1,4 @@
-import { type ServiceImplementation } from 'nice-grpc';
-import { type CompatServiceDefinition } from 'nice-grpc/lib/service-definitions';
+import { type ServiceImplementation, type CompatServiceDefinition } from 'nice-grpc';
 import { type RedisClientType, createClient } from 'redis';
 import {
   Server,

--- a/packages/resource-base-interface/tsconfig.json
+++ b/packages/resource-base-interface/tsconfig.json
@@ -12,7 +12,6 @@
   ],
   "compilerOptions": {
     "outDir": "lib",
-    "emitDecoratorMetadata": true,
     "experimentalDecorators": true
   },
 }


### PR DESCRIPTION
Tests for ACS Decorators are setup and runnable.
I workaround the unknown environment by a fallback strategy in my decorator function, covering all possible incoming parameter sets.

Sorry, but I had to clean-up the code a little, reducing redundancy, put helper functions to where they belong and spec some of the configs with default fallbacks.
By that I found that some expected configs did not exist at all, (e.g. in errors).
Futhermore, an operation_status with a string for an integer may cause the grpc serializer to crash.