### PR TITLE
fix: ignore malformed/empty filter entries that carry no nested filters

### DIFF
--- a/packages/resource-base-interface/src/index.ts
+++ b/packages/resource-base-interface/src/index.ts
@@ -79,7 +79,7 @@ const insertFilterFieldOpValue = (filter: Filter, object: any, key: string) => {
  * object with operator style understandable by chassis-srv for later to be used for
  * AQL conversion
  * @param object converted filter object
- * @param originalKey operator value
+ * @param operatorKey operator value
  * @param filter object containing field, operation, value and type
  * @returns object
  */
@@ -167,17 +167,19 @@ export const convertToObject = (input: any, obj?: any, currentOperator?: string)
  * @returns json object understandable by chassis-srv for AQL conversion
  */
 export const toObject = (input: ReadRequest) => {
-  const filters = input.filters ?? [];
-  const result: Record<string, any>[] = filters.map(
-    filter => {
-      const obj = filter.filters.map((sf) => convertToObject(sf, {}));
-      const operatorValue = filter?.operator ?? OperatorType.and; // defaults to `and`
-      return {
-        [`$${operatorValue}`]: obj
-      };
-    }
-  );
-  
+  const filters = input?.filters ?? [];
+  const result: Record<string, any>[] = filters
+    .filter(filter => Array.isArray(filter?.filters) && filter.filters.length > 0)
+    .map(
+      filter => {
+        const obj = filter.filters.map((sf) => convertToObject(sf, {}));
+        const operatorValue = filter?.operator ?? OperatorType.and; // defaults to `and`
+        return {
+          [`$${operatorValue}`]: obj
+        };
+      }
+    );
+
   return result.length === 1 ? result[0] : result;
 };
 


### PR DESCRIPTION
Handle requests which carry filters with no nested filters.

Err:

```text
error: 2026-07-13T16:09:44.265Z: Error caught while processing read request: Cannot read properties of undefined (reading 'map') [{"message":"Cannot read properties of undefined (reading 'map')","stack":"TypeError: Cannot read properties of undefined (reading 'map')\n    at /home/node/resource-srv/node_modules/@restorecommerce/resource-base-interface/src/index.ts:173:34\n    at Array.map (<anonymous>)\n    at toObject (/home/node/resource-srv/node_modules/@restorecommerce/resource-base-interface/src/index.ts:171:49)\n    at gQe.read (/home/node/resource-srv/node_modules/@restorecommerce/resource-base-interface/src/core/ServiceBase.ts:127:48)\n    at gQe.read (/home/node/resource-srv/node_modules/@restorecommerce/resource-srv/src/service.ts:98:26)\n    at processTicksAndRejections (node:internal/process/task_queues:104:5)\n    at Object.unaryMethodHandler [as next] (/home/node/resource-srv/node_modules/nice-grpc/src/server/handleUnaryCall.ts:34:12)\n    at /home/node/resource-srv/node_modules/@restorecommerce/chassis-srv/src/microservice/transport/provider/grpc/middlewares.ts:36:24\n    at metaMiddleware (/home/node/resource-srv/node_modules/@restorecommerce/chassis-srv/src/microservice/transport/provider/grpc/middlewares.ts:99:10)\n    at tracingMiddleware (/home/node/resource-srv/node_modules/@restorecommerce/chassis-srv/src/microservice/transport/provider/grpc/middlewares.ts:20:10)","name":"TypeError"}]
```